### PR TITLE
String decode retry

### DIFF
--- a/outlookmsgfile.py
+++ b/outlookmsgfile.py
@@ -304,7 +304,10 @@ class STRING8(VariableLengthValueLoader):
     # value is a bytestring. I haven't seen specified what character encoding
     # is used when the Unicode storage type is not used, so we'll assume it's
     # ASCII or Latin-1 like but we'll use UTF-8 to cover the bases.
-    return value.decode("utf8")
+    try:
+      return value.decode("utf8")
+    except UnicodeDecodeError:
+      return value.decode("unicode_escape")
 
 class UNICODE(VariableLengthValueLoader):
   @staticmethod
@@ -312,7 +315,10 @@ class UNICODE(VariableLengthValueLoader):
     # value is a bytestring. I haven't seen specified what character encoding
     # is used when the Unicode storage type is not used, so we'll assume it's
     # ASCII or Latin-1 like but we'll use UTF-8 to cover the bases.
-    return value.decode("utf16")
+    try:
+      return value.decode("utf16")
+    except UnicodeDecodeError:
+      return value.decode("unicode_escape")
 
 # TODO: The other variable-length tag types are "CLSID", "OBJECT".
 


### PR DESCRIPTION
When loading a string property, we aren't protected from encoding errors. Parsing a huge volume of msg files, sometimes I get `'utf-8' codec can't decode byte 0xNN in position NNNN: invalid start byte` due escaped unicode content.

To fix it, I propose to catch the encoding exceptions and parse them again using `unicode_escape` decoding.