### PR TITLE
Improve attachment filename normalization

### DIFF
--- a/outlookmsgfile.py
+++ b/outlookmsgfile.py
@@ -13,11 +13,11 @@
 # https://blogs.msdn.microsoft.com/openspecification/2009/11/06/msg-file-format-part-1/
 
 import re
+import os
 import sys
 
 from functools import reduce
 
-import urllib.parse
 import email.message, email.parser, email.policy
 from email.utils import parsedate_to_datetime, formatdate, formataddr
 
@@ -154,7 +154,7 @@ def process_attachment(msg, entry, doc):
   mime_type = props.get('ATTACH_MIME_TAG', 'application/octet-stream')
   if isinstance(mime_type, bytes): mime_type = mime_type.decode("utf8")
 
-  filename = urllib.parse.quote_plus(filename)
+  filename = os.path.basename(filename)
 
   # Python 3.6.
   if isinstance(blob, str):


### PR DESCRIPTION
The current implementation uses `urllib.parse.quote_plus` to normalize a filename of an attachment.

https://github.com/JoshData/convert-outlook-msg-file/blob/primary/outlookmsgfile.py#L157

It causes a problem like below. 

```python
urllib.parse.quote_plus("foo bar.txt") 
# ‘foo+bar.txt'
```

I don’t expect to convert a space with `+`.

Using `os.path.basename` instead of `urllib.parse.quote_plus` will generate a better result IMHO.

```python
os.path.basename("foo bar.txt")
# foo bar.txt'
```

For example, other library uses this technique.

https://github.com/vikramarsid/msg_parser/blob/d8e6d108a07c142d282a1e64cb72704f6cc28ad7/msg_parser/email_builder.py#L123