### PR TITLE
Fix removing of Content-Type header from transport headers

### DIFF
--- a/outlookmsgfile.py
+++ b/outlookmsgfile.py
@@ -51,7 +51,7 @@ def load_message_stream(entry, is_top_level, doc):
     # way is just the plain-text portion of the email and whatever
     # Content-Type header was in the original is not valid for
     # reconstructing it this way.
-    headers = re.sub("Content-Type: .*(\n\s.*)*\n", "", headers, re.I)
+    headers = re.sub("Content-Type: .*(\n\s.*)*\n", "", headers, flags=re.I)
 
     # Parse them.
     headers = email.parser.HeaderParser(policy=email.policy.default)\


### PR DESCRIPTION
The fourth argument to `re.sub` is `count`, but `re.I` (a flag) was passed
instead.

Because if this, messages with a lower-case "content-type" header would
never have their content-type header removed, leading to parse errors.

By explicity naming the parameter (`flags=`) to re.sub, the match
actually becomes case-insensitive.