### PR TITLE
Skip attachments without "__properties_version1.0" streams

### DIFF
--- a/outlookmsgfile.py
+++ b/outlookmsgfile.py
@@ -135,7 +135,11 @@ def load_message_stream(entry, is_top_level, doc):
   # Add attachments.
   for stream in entry:
     if stream.name.startswith("__attach_version1.0_#"):
-      process_attachment(msg, stream, doc)
+      try:
+        process_attachment(msg, stream, doc)
+      except KeyError as e:
+        print("Error processing attachment {} not found".format(str(e)), file=sys.stderr)
+        continue
 
   return msg
 
@@ -229,7 +233,11 @@ def parse_properties(properties, is_top_level, container, doc):
         # Stream isn't present!
         print("stream missing", streamname, file=sys.stderr)
         continue
-      value = tag_type.load(value, doc)
+      try:
+        value = tag_type.load(value, doc)
+      except KeyError as e:
+        print("Error while reading stream: {} not found".format(str(e)) , file=sys.stderr)
+        continue
 
     else:
       # unrecognized type


### PR DESCRIPTION
We've found that messages with RTF formatting that contain embedded images
contain attachments without a "__properties_version1.0" stream.

As the current code is built around the "__properties_version1.0" stream,
these are skipped for now.

These image attachments do contain streams named "Ole" and "MailStream"
that should help with decoding/parsing in the future, but that's a bigger
project.