### PR TITLE
Fix a crash when all 64 bits in timestamp are 1

### DIFF
--- a/outlookmsgfile.py
+++ b/outlookmsgfile.py
@@ -293,7 +293,11 @@ class INTTIME(FixedLengthValueLoader):
     # 100-nanosecond intervals since January 1, 1601.
     from datetime import datetime, timedelta
     value = reduce(lambda a, b : (a<<8)+b, reversed(value)) # bytestring to integer
-    value = datetime(1601, 1, 1) + timedelta(seconds=value/10000000)
+    try:
+        value = datetime(1601, 1, 1) + timedelta(seconds=value/10000000)
+    except OverflowError:
+        value = None
+
     return value
 
 # TODO: The other fixed-length data types:


### PR DESCRIPTION
We've found some .msg files in the wild that have a CREATION_TIME that
has all 64 bits set: 9223372036854775807.

Adding this number of 100ns intervals to the base timestamp of 1601-01-01
results in a timestamp somewhere in the year 30828 which is not
supported by Python's datetime module, as datetime.MAXYEAR is currently
9999.