### PR TITLE
Use a raw string in re, so \n and \s work

### DIFF
--- a/outlookmsgfile.py
+++ b/outlookmsgfile.py
@@ -54,7 +54,7 @@ def load_message_stream(entry, is_top_level, doc):
     # way is just the plain-text portion of the email and whatever
     # Content-Type header was in the original is not valid for
     # reconstructing it this way.
-    headers = re.sub("Content-Type: .*(\n\s.*)*\n", "", headers, flags=re.I)
+    headers = re.sub(r"Content-Type: .*(\n\s.*)*\n", "", headers, flags=re.I)
 
     # Parse them.
     headers = email.parser.HeaderParser(policy=email.policy.default)\


### PR DESCRIPTION
Newer versions of Python complain about "\s" not being correct syntax
(SyntaxError during import); changing the string to a raw string fixes
the issue.